### PR TITLE
Pin commons purge workflow to v1.0.1 SHA

### DIFF
--- a/.github/workflows/_purge.yaml
+++ b/.github/workflows/_purge.yaml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   purge-logs:
-    uses: ulfiac/commons/.github/workflows/reusable_purge_workflow_logs.yaml@main
+    uses: ulfiac/commons/.github/workflows/reusable_purge_workflow_logs.yaml@f59794cccc40cb197f7f0b5787f11a3de82bdf4f # v1.0.1


### PR DESCRIPTION
Switches `reusable_purge_workflow_logs.yaml` from `@main` to an immutable SHA (`v1.0.1`), with a version comment so Renovate can track and PR future updates. Test case for rolling this out across the remaining commons workflow references.