### PR TITLE
Pin remaining commons workflow references to v1.0.1 SHA

### DIFF
--- a/.github/workflows/_linter.yaml
+++ b/.github/workflows/_linter.yaml
@@ -12,4 +12,4 @@ permissions:
 
 jobs:
   reusable-linter:
-    uses: ulfiac/commons/.github/workflows/reusable_linter.yaml@main
+    uses: ulfiac/commons/.github/workflows/reusable_linter.yaml@f59794cccc40cb197f7f0b5787f11a3de82bdf4f # v1.0.1

--- a/.github/workflows/_terraform_docs.yaml
+++ b/.github/workflows/_terraform_docs.yaml
@@ -20,6 +20,6 @@ permissions:
 
 jobs:
   terraform-docs:
-    uses: ulfiac/commons/.github/workflows/reusable_terraform_docs.yaml@main
+    uses: ulfiac/commons/.github/workflows/reusable_terraform_docs.yaml@f59794cccc40cb197f7f0b5787f11a3de82bdf4f # v1.0.1
     with:
       find-dir: 'terraform'


### PR DESCRIPTION
Switches `reusable_linter.yaml` and `reusable_terraform_docs.yaml` from `@main` to an immutable SHA (`v1.0.1`), with a version comment so Renovate can track and PR future updates. Companion to #85, which already validated this pin pattern against `reusable_purge_workflow_logs.yaml`.